### PR TITLE
Prevent navigation to the same destination in BottomNavigationBar

### DIFF
--- a/navigation/feat-navigation/src/main/java/com/seravian/feat_navigation/components/BottomNavigationBar.kt
+++ b/navigation/feat-navigation/src/main/java/com/seravian/feat_navigation/components/BottomNavigationBar.kt
@@ -51,7 +51,13 @@ private fun BottomBarContent(
         if (currentAccountTypeIndex == 0) {
             PatientDestination.entries.forEach { destination ->
                 NavigationBarItem(
-                    onClick = { defaultNavigationMethod(NavigationType.BottomNavigation(destination.target)) },
+                    onClick = {
+                        if (currentDestination::class != destination.target::class) {
+                            defaultNavigationMethod(
+                                NavigationType.BottomNavigation(destination.target)
+                            )
+                        }
+                    },
                     icon = {
                         Icon(
                             painter = painterResource(destination.icon),


### PR DESCRIPTION
The `BottomNavigationBar` now checks if the target destination is different from the current destination before navigating. This prevents redundant navigation actions when the user taps on the currently active bottom navigation item.